### PR TITLE
Redmine 4.x support

### DIFF
--- a/lib/journal_patch.rb
+++ b/lib/journal_patch.rb
@@ -6,7 +6,8 @@ module JournalPatch
     base.send(:include, InstanceMethods)
     base.class_eval do
       unloadable # Send unloadable so it will not be unloaded in development
-      alias_method_chain :visible_details, :patch
+      alias_method :visible_details_without_patch, :visible_details
+      alias_method :visible_details, :visible_details_with_patch
     end
   end
 

--- a/lib/pdf_patch.rb
+++ b/lib/pdf_patch.rb
@@ -7,7 +7,8 @@ module IssuesPdfHelperPatch
     base.send(:include, InstanceMethods)
     base.class_eval do
       unloadable # Send unloadable so it will not be unloaded in development
-      alias_method_chain :issue_to_pdf, :patch
+      alias_method :issue_to_pdf_without_patch, :issue_to_pdf
+      alias_method :issue_to_pdf, :issue_to_pdf_with_patch
     end
   end
 

--- a/lib/query_patch.rb
+++ b/lib/query_patch.rb
@@ -6,7 +6,8 @@ module QueryPatch
     base.send(:include, InstanceMethods)
     base.class_eval do
       unloadable # Send unloadable so it will not be unloaded in development
-      alias_method_chain :available_filters, :patch
+      alias_method :available_filters_without_patch, :available_filters
+      alias_method :available_filters, :available_filters_with_patch
     end
   end
 
@@ -28,7 +29,8 @@ module IssueQueryPatch
     base.send(:include, InstanceMethods)
     base.class_eval do
       unloadable # Send unloadable so it will not be unloaded in development
-      alias_method_chain :available_columns, :patch
+      alias_method :available_columns_without_patch, :available_columns
+      alias_method :available_columns, :available_columns_with_patch
     end
   end
 


### PR DESCRIPTION
From #21.

Deprecated `alias_method_chain` replaced with `alias_method`.